### PR TITLE
Fix for attribute operations resulting in string operations

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ var optimize = function(ops) {
   return ops;
 };
 
-var diff = function(input, output, path = []) {
+var diff = function(input, output, path = [], treatAsStringOp) {
   // If the last element of the path is a string, that means we're looking at a key, rather than
   // a number index. Objects use keys, so the target for our insertion/deletion is an object.
   var isObject = typeof path[path.length - 1] === 'string';
@@ -75,7 +75,7 @@ var diff = function(input, output, path = []) {
   }
 
   // This should do a string OT operation instead of what it is doing.
-  if (typeof output === 'string' && typeof input === 'string') {
+  if ((treatAsStringOp || treatAsStringOp === undefined) && typeof output === 'string' && typeof input === 'string') {
     var ops = [];
     var d = characterDiff(input, output);
     var idx = 0;
@@ -105,7 +105,7 @@ var diff = function(input, output, path = []) {
     var ops = [];
     var offset = 0;
     for (var i = 0; i < l; ++i) {
-      var newOps = diff(input[i], output[i], [...path, i + offset]);
+      var newOps = diff(input[i], output[i], [...path, i + offset], true);
       newOps.forEach(function(op) {
         var opParentPath = op.p.slice(0, -1);
         if (equal(path, opParentPath)) {
@@ -123,7 +123,7 @@ var diff = function(input, output, path = []) {
   ).sort();
 
   keys.forEach(function(key) {
-    var newOps = diff(input[key], output[key], [...path, key]);
+    var newOps = diff(input[key], output[key], [...path, key], false);
     ops = ops.concat(newOps);
   });
   return ops;

--- a/tests.js
+++ b/tests.js
@@ -8,7 +8,7 @@ var jsondiff = require('./index.js');
 var tests = [
   //tests of li/ld
   [[], ['foo']],
-  [['foo'], ['bar']],
+  [['foo'], ['bar'], [{p: [0], t: 'text0', o: [{p: 0, d: 'foo'}, {p: 0, i: 'bar'}]}]],
   [['foo', 'bar'], ['bar']],
   [['foo', 'bar', 'quux'], ['bar']],
   [[['foo', 'bar'], 'bar'], ['bar', 'bar']],
@@ -113,6 +113,51 @@ var tests = [
     ]
   ],
   [
+    [
+      'html',
+      {},
+      '\n',
+      [
+        'body',
+        { contenteditable: 'true' },
+        ['p', {}, 'foo'],
+      ],
+      '\n'
+    ],
+    [
+      'html',
+      {},
+      '\n',
+      [
+        'body',
+        { contenteditable: 'false' },
+        ['p', {}, 'bar']
+      ],
+      '\n'
+    ],
+	[
+	  {
+		p: [3, 1, 'contenteditable'],
+		od: 'true',
+		oi: 'false'
+	  }, 
+	  {
+		p: [3, 2, 2],
+		o: [
+		  {
+			p: 0,
+			d: 'foo'
+		  },
+		  {
+			p: 0,
+			i: 'bar'
+		  }
+		],
+		t: 'text0'
+	  }
+	]
+  ],
+  [
     {
       value: 0
     },
@@ -155,9 +200,21 @@ tests.forEach(function([input, output]) {
   assert.deepEqual(coutput, output);
 });
 
+// Expected ops for each test
+tests.forEach(function([input, output, expectedOps]) {
+  if (expectedOps) {
+    var ops = jsondiff(input, output);
+    // console.log(require("util").inspect(ops, { showHidden: true, depth: null }));
+    expectedOps.forEach(function(expectedOp, opIndex) {
+	    assert.deepEqual(ops[opIndex], expectedOp);
+    });
+  }
+});
+
 // Actual tests
 tests.forEach(function([input, output]) {
   var ops = jsondiff(input, output);
+  var util = require("util");
   ops.forEach(function(op) {
     // assert.doesNotThrow(
     //   function() {
@@ -169,5 +226,7 @@ tests.forEach(function([input, output]) {
   });
   assert.deepEqual(input, output);
 });
+
+
 
 console.log('No errors!');

--- a/tests.js
+++ b/tests.js
@@ -200,20 +200,17 @@ tests.forEach(function([input, output]) {
   assert.deepEqual(coutput, output);
 });
 
-// Expected ops for each test
+// Actual tests
 tests.forEach(function([input, output, expectedOps]) {
+  var ops = jsondiff(input, output);
+
+  // Expected ops for each test, if they exist
   if (expectedOps) {
-    var ops = jsondiff(input, output);
-    // console.log(require("util").inspect(ops, { showHidden: true, depth: null }));
     expectedOps.forEach(function(expectedOp, opIndex) {
 	    assert.deepEqual(ops[opIndex], expectedOp);
     });
   }
-});
 
-// Actual tests
-tests.forEach(function([input, output]) {
-  var ops = jsondiff(input, output);
   ops.forEach(function(op) {
     // assert.doesNotThrow(
     //   function() {

--- a/tests.js
+++ b/tests.js
@@ -214,7 +214,6 @@ tests.forEach(function([input, output, expectedOps]) {
 // Actual tests
 tests.forEach(function([input, output]) {
   var ops = jsondiff(input, output);
-  var util = require("util");
   ops.forEach(function(op) {
     // assert.doesNotThrow(
     //   function() {
@@ -226,7 +225,5 @@ tests.forEach(function([input, output]) {
   });
   assert.deepEqual(input, output);
 });
-
-
 
 console.log('No errors!');


### PR DESCRIPTION
This PR contains a fix for attribute operations (object - oi and od) being converted to string operations within the 'diff' function (index.js, line 47).

This is not an issue if the target attribute does not exist or is being removed, however when changing an attribute value, string operations will be generated (i.e contenteditable='true' to contenteditable='false').

Added a new test scenario and added expected ops for the second existing test. The tests run properly with the 'No errors!' message showing at the end.

Notes:
1. Line 78 in index.js - The condition 'treatAsStringOp === undefined' is required for the unicode test scenarios
2. Line 209 in tests.js - The assertion is done in an ordered manner

@tberman 